### PR TITLE
fix class include for ecm

### DIFF
--- a/class/history.class.php
+++ b/class/history.class.php
@@ -34,7 +34,11 @@ class DeepHistory extends SeedObject {
 	function show_ref() {
 		global $db,$user,$conf,$langs;
 
-		dol_include_once('/'.$this->type_object.'/class/'.$this->type_object.'.class.php');
+		if ($this->type_object == 'ecmfiles') {
+			dol_include_once('/ecm/class/'.$this->type_object.'.class.php');
+		} else {
+			dol_include_once('/'.$this->type_object.'/class/'.$this->type_object.'.class.php');
+		}
 
 		$class = ucfirst($this->type_object);
 


### PR DESCRIPTION
the ecm module does not follow naming conventions and thereby the class file can not be included where dynamically retrieved