### PR TITLE
PULLUP  : Test des clés des fields  - *21/02/2025* - 2.3.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ## Release 2.3
+- FIX : Test des clés des fields  - *21/02/2025* - 2.3.5
+        Suppression de $checkArrayOptions, plus nécéssaire dans la nouvelle gestion => provoquer des doublons dans l'onglet 
 - FIX : Conversion des tms en date - *20/02/2025* - 2.3.4
         Ajout des trads sur les champs standard et extrafields
 - FIX : missed contact class in file history.php - *17/02/2025* - 2.3.3  

--- a/class/history.class.php
+++ b/class/history.class.php
@@ -74,10 +74,9 @@ class DeepHistory extends SeedObject {
     function compare(&$newO, &$oldO) {
     	$this->what_changed = '';
         $this->what_changed .= $this->cmp($newO, $oldO);
-    	$this->what_changed .= $this->cmp($newO, $oldO, true);
     }
 
-    private function cmp(&$newO, &$oldO, $checkArrayOptions = false) {
+    private function cmp(&$newO, &$oldO) {
 		global $langs, $db;
 
         if( empty($newO) || empty($oldO) ) return '';
@@ -89,7 +88,7 @@ class DeepHistory extends SeedObject {
 		$extrafields->fetch_name_optionals_label($newO->table_element);
 
         foreach($newO as $k => $v) {
-			if ($checkArrayOptions && $k == "array_options") {
+			if ($k == "array_options") {
 				foreach($v as $k2 => $v2) {
 					if ($oldO->array_options[$k2] != $v2) {
 						$name = substr($k2,8);
@@ -106,7 +105,7 @@ class DeepHistory extends SeedObject {
 					&& (!empty($v) || (!empty($oldO->{$k}) &&  $oldO->{$k} !== '0.000' )   )
 				) {
 
-					if ($oldO->fields[$k]) {
+					if (isset($oldO->fields[$k]) && $oldO->fields[$k]) {
 							$propName = $oldO->fields[$k]['label'];
 
 							if ($oldO->fields[$k]['type'] == 'datetime' || $oldO->fields[$k]['type'] == 'date') {

--- a/core/modules/modHistory.class.php
+++ b/core/modules/modHistory.class.php
@@ -62,7 +62,7 @@ class modHistory extends DolibarrModules
 		$this->description = "Description of module History";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '2.3.4';
+		$this->version = '2.3.5';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);


### PR DESCRIPTION
                       Suppression de , plus nécéssaire dans la nouvelle gestion => provoquer des doublons dans l'onglet